### PR TITLE
🔨 Remove the wait abstruction

### DIFF
--- a/hyx/common/waiter.py
+++ b/hyx/common/waiter.py
@@ -1,8 +1,0 @@
-import asyncio
-
-
-async def wait(seconds: float) -> None:
-    """
-    Abstract way the actual waiting function
-    """
-    await asyncio.sleep(seconds)

--- a/hyx/retry/manager.py
+++ b/hyx/retry/manager.py
@@ -1,7 +1,7 @@
+import asyncio
 from typing import Any
 
 from hyx.common.typing import ExceptionsT, FuncT
-from hyx.common.waiter import wait
 from hyx.retry.backoffs import create_backoff
 from hyx.retry.counters import create_counter
 from hyx.retry.typing import AttemptsT, BackoffsT
@@ -19,7 +19,6 @@ class RetryManager:
         self._exceptions = exceptions
         self._attempts = attempts
         self._backoff = create_backoff(backoff)
-        self._waiter = wait
 
     async def __call__(self, func: FuncT) -> Any:
         counter = create_counter(self._attempts)
@@ -30,6 +29,4 @@ class RetryManager:
                 return await func()
             except self._exceptions:
                 counter += 1
-
-                next_delay = next(backoff)
-                await self._waiter(next_delay)
+                await asyncio.sleep(next(backoff))


### PR DESCRIPTION
This was a premature optimization. If I ever decided to abstract asyncio away, it would be AnyIO-like solution.  